### PR TITLE
Initial models

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+cache/
+out/

--- a/foundry.toml
+++ b/foundry.toml
@@ -4,7 +4,7 @@ out = "out"
 libs = ["dependencies"]
 auto_detect_remappings = false
 remappings = [
-    "forge-std-1.9.5/=dependencies/forge-std-1.9.5/"
+    "forge-std/=dependencies/forge-std-1.9.5/src/"
 ]
 evm_version = "cancun"
 solc = "0.8.28"

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.28;
+
+import {IPoolManager} from "./interfaces/IPoolManager.sol";
+import {Pool} from "./models/Pool.sol";
+import {PoolId} from "./models/PoolId.sol";
+
+contract PoolManager is IPoolManager {
+    mapping(PoolId => Pool) pools;
+}

--- a/src/interfaces/IConfigs.sol
+++ b/src/interfaces/IConfigs.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IConfigs
+interface IConfigs {}

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @title IPoolManager
+interface IPoolManager {}

--- a/src/models/Order.sol
+++ b/src/models/Order.sol
@@ -1,0 +1,7 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct Order {
+    address maker;
+    uint128 amount;
+}

--- a/src/models/Order.sol
+++ b/src/models/Order.sol
@@ -3,5 +3,7 @@ pragma solidity ^0.8.0;
 
 struct Order {
     address maker;
+    bool zeroForOne;
     uint128 amount;
+    uint128 amountFilled;
 }

--- a/src/models/OrderId.sol
+++ b/src/models/OrderId.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @dev Layout: 32 tick | 160 pool id | 32 index
+/// @dev Layout: 32 tick (uint32) | 160 pool id (PoolId) | 32 index (uint32)
 type OrderId is bytes28;

--- a/src/models/OrderId.sol
+++ b/src/models/OrderId.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @dev Layout: 32 tick (uint32) | 160 pool id (PoolId) | 32 index (uint32)
-type OrderId is bytes28;
+/// @dev Layout: 32 tick (uint32) | 160 pool id (PoolId) | 64 index (uint64)
+type OrderId is bytes32;

--- a/src/models/OrderId.sol
+++ b/src/models/OrderId.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @dev Layout: 32 tick | 32 index
+type OrderId is bytes8;

--- a/src/models/OrderId.sol
+++ b/src/models/OrderId.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @dev Layout: 32 tick | 32 index
-type OrderId is bytes8;
+/// @dev Layout: 32 tick | 160 pool id | 32 index
+type OrderId is bytes28;

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: BUSL-1.1
 pragma solidity =0.8.28;
 
-import {Order} from "./Order.sol";
-import {OrderId} from "./OrderId.sol";
 import {Tick} from "./Tick.sol";
 
 struct Pool {
@@ -13,5 +11,4 @@ struct Pool {
     uint32 topAsk;
     uint32 topBid;
     mapping(uint32 => Tick) ticks;
-    mapping(OrderId => Order) orders;
 }

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -1,0 +1,17 @@
+// SPDX-License-Identifier: BUSL-1.1
+pragma solidity =0.8.28;
+
+import {Order} from "./Order.sol";
+import {OrderId} from "./OrderId.sol";
+import {Tick} from "./Tick.sol";
+
+struct Pool {
+    uint160 sqrtPriceX96;
+    uint160 sqrtPriceLowerX96;
+    uint160 sqrtPriceUpperX96;
+    uint128 liquidity;
+    uint32 topAsk;
+    uint32 topBid;
+    mapping(uint32 => Tick) ticks;
+    mapping(OrderId => Order) orders;
+}

--- a/src/models/PoolId.sol
+++ b/src/models/PoolId.sol
@@ -1,5 +1,4 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @dev lower 160 bits of the keccak256 hash of pool key
-type PoolId is bytes20;
+type PoolId is bytes32;

--- a/src/models/PoolId.sol
+++ b/src/models/PoolId.sol
@@ -1,0 +1,5 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+/// @dev lower 160 bits of the keccak256 hash of pool key
+type PoolId is bytes20;

--- a/src/models/PoolId.sol
+++ b/src/models/PoolId.sol
@@ -1,4 +1,5 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-type PoolId is bytes32;
+/// @dev lower 160 bits of the keccak256 hash of pool key
+type PoolId is bytes20;

--- a/src/models/PoolKey.sol
+++ b/src/models/PoolKey.sol
@@ -21,7 +21,7 @@ library PoolKeyLibrary {
             mstore(20, calldataload(add(self, 44)))
             mstore(32, or(shl(192, calldataload(add(self, 32))), calldataload(add(self, 68))))
 
-            poolId := keccak256(0, 60)
+            poolId := and(keccak256(0, 60), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
         }
     }
 }

--- a/src/models/PoolKey.sol
+++ b/src/models/PoolKey.sol
@@ -21,7 +21,7 @@ library PoolKeyLibrary {
             mstore(20, calldataload(add(self, 44)))
             mstore(32, or(shl(192, calldataload(add(self, 32))), calldataload(add(self, 68))))
 
-            poolId := and(keccak256(0, 60), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+            poolId := keccak256(0, 60)
         }
     }
 }

--- a/src/models/PoolKey.sol
+++ b/src/models/PoolKey.sol
@@ -1,0 +1,27 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {IConfigs} from "../interfaces/IConfigs.sol";
+import {PoolId} from "./PoolId.sol";
+import {Token} from "./Token.sol";
+
+struct PoolKey {
+    Token token0;
+    Token token1;
+    IConfigs configs;
+}
+
+using PoolKeyLibrary for PoolKey global;
+
+/// @title PoolKeyLibrary
+library PoolKeyLibrary {
+    function toId(PoolKey calldata self) internal pure returns (PoolId poolId) {
+        assembly {
+            mstore(0, calldataload(add(self, 12)))
+            mstore(20, calldataload(add(self, 44)))
+            mstore(32, or(shl(192, calldataload(add(self, 32))), calldataload(add(self, 68))))
+
+            poolId := and(keccak256(0, 60), 0xFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFFF)
+        }
+    }
+}

--- a/src/models/Tick.sol
+++ b/src/models/Tick.sol
@@ -1,0 +1,10 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+struct Tick {
+    uint32 prev;
+    uint32 next;
+    uint32 lastOpenOrder;
+    uint32 lastCloseOrder;
+    uint128 totalAmount;
+}

--- a/src/models/Tick.sol
+++ b/src/models/Tick.sol
@@ -1,10 +1,14 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {Order} from "./Order.sol";
+import {OrderId} from "./OrderId.sol";
+
 struct Tick {
+    uint64 lastOpenOrder;
+    uint64 lastCloseOrder;
+    uint128 totalAmountOpen;
     uint32 prev;
     uint32 next;
-    uint32 lastOpenOrder;
-    uint32 lastCloseOrder;
-    uint128 totalAmount;
+    mapping(OrderId => Order) orders;
 }

--- a/src/models/Token.sol
+++ b/src/models/Token.sol
@@ -1,0 +1,4 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+type Token is address;


### PR DESCRIPTION
- use uint32 for tick key rather than uint160 sqrtPrice. Key may overflow but is safe so long as there isn't 2^32 open orders on this tick

- reduced tick from 3 slots to 1

- reduced orderId from bytes32 to bytes8

- removed direction and filled amount from order

- removed rebase related fields out of pool for now