### PR TITLE
Shares related function

### DIFF
--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -21,46 +21,32 @@ contract PoolManager is IPoolManager {
     }
 
     /// @inheritdoc IPoolManager
-    function initialize(PoolKey calldata poolKey, SqrtPrice sqrtPrice)
+    function initialize(PoolKey calldata poolKey, SqrtPrice sqrtPrice, uint128 amount0Desired, uint128 amount1Desired)
         external
         validatePoolKey(poolKey)
-        returns (PoolId poolId, IShareToken shareToken)
+        returns (PoolId poolId, IShareToken shareToken, uint128 shares, BalanceDelta balanceDelta)
     {
         poolId = poolKey.toId();
         shareToken = new ShareToken{salt: PoolId.unwrap(poolId)}();
-        (uint24 rangeRatioLower, uint24 rangeRatioUpper, uint24 thresholdRatioLower, uint24 thresholdRatioUpper) =
-            _pools[poolId].initialize(shareToken, sqrtPrice, poolKey.configs);
+        (shares, balanceDelta) =
+            _pools[poolId].initialize(poolKey.configs, shareToken, sqrtPrice, amount0Desired, amount1Desired);
 
         emit Initialize(
-            poolId,
-            poolKey.token0,
-            poolKey.token1,
-            poolKey.configs,
-            shareToken,
-            sqrtPrice,
-            rangeRatioLower,
-            rangeRatioUpper,
-            thresholdRatioLower,
-            thresholdRatioUpper
+            poolKey.token0, poolKey.token1, poolKey.configs, poolId, shareToken, sqrtPrice, shares, balanceDelta
         );
     }
 
     /// @inheritdoc IPoolManager
-    function mint(PoolKey calldata poolKey, uint128 amount0, uint128 amount1)
+    function modifyReserves(PoolKey calldata poolKey, int128 sharesDelta)
         external
         validatePoolKey(poolKey)
-        returns (BalanceDelta balanceDelta, int128 shareDelta)
+        returns (BalanceDelta balanceDelta)
     {
-        // TODO: Implement
-    }
+        PoolId poolId = poolKey.toId();
 
-    /// @inheritdoc IPoolManager
-    function burn(PoolKey calldata poolKey, uint128 share)
-        external
-        validatePoolKey(poolKey)
-        returns (BalanceDelta balanceDelta, int128 shareDelta)
-    {
-        // TODO: Implement
+        balanceDelta = _pools[poolId].modifyReserves(sharesDelta);
+
+        emit ModifyReserves(poolId, msg.sender, sharesDelta, balanceDelta);
     }
 
     /// @inheritdoc IPoolManager

--- a/src/PoolManager.sol
+++ b/src/PoolManager.sol
@@ -9,7 +9,6 @@ import {Pool} from "./models/Pool.sol";
 import {PoolId} from "./models/PoolId.sol";
 import {PoolKey} from "./models/PoolKey.sol";
 import {SqrtPrice} from "./models/SqrtPrice.sol";
-import {ShareToken} from "./ShareToken.sol";
 
 /// @title PoolManager
 contract PoolManager is IPoolManager {
@@ -27,9 +26,8 @@ contract PoolManager is IPoolManager {
         returns (PoolId poolId, IShareToken shareToken, uint128 shares, BalanceDelta balanceDelta)
     {
         poolId = poolKey.toId();
-        shareToken = new ShareToken{salt: PoolId.unwrap(poolId)}();
-        (shares, balanceDelta) =
-            _pools[poolId].initialize(poolKey.configs, shareToken, sqrtPrice, amount0Desired, amount1Desired);
+        (shareToken, shares, balanceDelta) =
+            _pools[poolId].initialize(poolKey, sqrtPrice, amount0Desired, amount1Desired);
 
         emit Initialize(
             poolKey.token0, poolKey.token1, poolKey.configs, poolId, shareToken, sqrtPrice, shares, balanceDelta

--- a/src/ShareToken.sol
+++ b/src/ShareToken.sol
@@ -89,7 +89,10 @@ contract ShareToken is IShareToken {
         // over/underflow not possible
         unchecked {
             if (to == address(0)) {
-                _totalSupply -= amount;
+                // allow explicitly minting to address(0)
+                if (from != address(0)) {
+                    _totalSupply -= amount;
+                }
             } else {
                 _accounts[to].balance += amount;
             }

--- a/src/interfaces/IConfigs.sol
+++ b/src/interfaces/IConfigs.sol
@@ -8,7 +8,6 @@ import {Token} from "../models/Token.sol";
 /// @title IConfigs
 interface IConfigs {
     /// @notice Initializes a pool's configs
-    /// @param poolId The pool id
     /// @param token0 The token0 address
     /// @param token1 The token1 address
     /// @param sqrtPrice The initial square root price
@@ -17,7 +16,7 @@ interface IConfigs {
     /// @return thresholdRatioLower The lower threshold ratio
     /// @return thresholdRatioUpper The upper threshold ratio
     /// @return minShares The minimum shares
-    function initialize(PoolId poolId, Token token0, Token token1, SqrtPrice sqrtPrice)
+    function initialize(Token token0, Token token1, SqrtPrice sqrtPrice)
         external
         returns (
             uint24 rangeRatioLower,

--- a/src/interfaces/IConfigs.sol
+++ b/src/interfaces/IConfigs.sol
@@ -1,19 +1,29 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {PoolId} from "../models/PoolId.sol";
 import {SqrtPrice} from "../models/SqrtPrice.sol";
+import {Token} from "../models/Token.sol";
 
 /// @title IConfigs
 interface IConfigs {
-    /// @notice Gets the ratios given current square root price and reserve amounts
-    /// @param sqrtPrice The current square root price
-    /// @param reserve0 The reserve amount of token0
-    /// @param reserve1 The reserve amount of token1
+    /// @notice Initializes a pool's configs
+    /// @param poolId The pool id
+    /// @param token0 The token0 address
+    /// @param token1 The token1 address
+    /// @param sqrtPrice The initial square root price
     /// @return rangeRatioLower The lower range ratio
     /// @return rangeRatioUpper The upper range ratio
     /// @return thresholdRatioLower The lower threshold ratio
     /// @return thresholdRatioUpper The upper threshold ratio
-    function getRatios(SqrtPrice sqrtPrice, uint128 reserve0, uint128 reserve1)
+    /// @return minShares The minimum shares
+    function initialize(PoolId poolId, Token token0, Token token1, SqrtPrice sqrtPrice)
         external
-        returns (uint24 rangeRatioLower, uint24 rangeRatioUpper, uint24 thresholdRatioLower, uint24 thresholdRatioUpper);
+        returns (
+            uint24 rangeRatioLower,
+            uint24 rangeRatioUpper,
+            uint24 thresholdRatioLower,
+            uint24 thresholdRatioUpper,
+            uint32 minShares
+        );
 }

--- a/src/interfaces/IPoolManager.sol
+++ b/src/interfaces/IPoolManager.sol
@@ -13,42 +13,31 @@ import {Token} from "../models/Token.sol";
 /// @title IPoolManager
 interface IPoolManager {
     /// @notice Emitted when a new pool is initialized
-    /// @param poolId The pool id
     /// @param token0 The first token
     /// @param token1 The second token
     /// @param configs The pool configs
+    /// @param poolId The pool id
     /// @param shareToken The share token
     /// @param sqrtPrice The initial square root price
-    /// @param rangeRatioLower The lower range ratio
-    /// @param rangeRatioUpper The upper range ratio
-    /// @param thresholdRatioLower The lower threshold ratio
-    /// @param thresholdRatioUpper The upper threshold ratio
+    /// @param shares The initial shares
+    /// @param balanceDelta The balance delta required
     event Initialize(
-        PoolId indexed poolId,
         Token indexed token0,
         Token indexed token1,
-        IConfigs configs,
+        IConfigs indexed configs,
+        PoolId poolId,
         IShareToken shareToken,
         SqrtPrice sqrtPrice,
-        uint24 rangeRatioLower,
-        uint24 rangeRatioUpper,
-        uint24 thresholdRatioLower,
-        uint24 thresholdRatioUpper
+        uint128 shares,
+        BalanceDelta balanceDelta
     );
 
-    /// @notice Emitted when share is minted
+    /// @notice Emitted when the reserves of a pool are modified
     /// @param poolId The pool id
     /// @param sender The sender
-    /// @param balanceDelta The balance delta for the sender
-    /// @param shareDelta The share delta for the sender
-    event Mint(PoolId indexed poolId, address indexed sender, BalanceDelta balanceDelta, int128 shareDelta);
-
-    /// @notice Emitted when share is burned
-    /// @param poolId The pool id
-    /// @param sender The sender
-    /// @param balanceDelta The balance delta for the sender
-    /// @param shareDelta The share delta for the sender
-    event Burn(PoolId indexed poolId, address indexed sender, BalanceDelta balanceDelta, int128 shareDelta);
+    /// @param sharesDelta The shares delta
+    /// @param balanceDelta The balance delta required or received
+    event ModifyReserves(PoolId indexed poolId, address indexed sender, int128 sharesDelta, BalanceDelta balanceDelta);
 
     // TODO: PlaceOrder event
 
@@ -64,30 +53,23 @@ interface IPoolManager {
     /// @notice Initializes a new pool
     /// @param poolKey The pool key
     /// @param sqrtPrice The initial square root price
+    /// @param amount0Desired The desired initial amount of token0
+    /// @param amount1Desired The desired initial amount of token1
     /// @return poolId The pool id
     /// @return shareToken The share token
-    function initialize(PoolKey calldata poolKey, SqrtPrice sqrtPrice)
-        external
-        returns (PoolId poolId, IShareToken shareToken);
-
-    /// @notice Mints share
-    /// @param poolKey The pool key
-    /// @param amount0 The desired amount of token0 to provide
-    /// @param amount1 The desired amount of token1 to provide
+    /// @return shares The initial shares
     /// @return balanceDelta The balance delta required
-    /// @return shareDelta The share delta received
-    function mint(PoolKey calldata poolKey, uint128 amount0, uint128 amount1)
+    function initialize(PoolKey calldata poolKey, SqrtPrice sqrtPrice, uint128 amount0Desired, uint128 amount1Desired)
         external
-        returns (BalanceDelta balanceDelta, int128 shareDelta);
+        returns (PoolId poolId, IShareToken shareToken, uint128 shares, BalanceDelta balanceDelta);
 
-    /// @notice Burns share
+    /// @notice Modifies the reserves of a pool
     /// @param poolKey The pool key
-    /// @param share The amount of share to burn
-    /// @return balanceDelta The balance delta received
-    /// @return shareDelta The share delta required
-    function burn(PoolKey calldata poolKey, uint128 share)
+    /// @param sharesDelta The shares delta
+    /// @return balanceDelta The balance delta required or received
+    function modifyReserves(PoolKey calldata poolKey, int128 sharesDelta)
         external
-        returns (BalanceDelta balanceDelta, int128 shareDelta);
+        returns (BalanceDelta balanceDelta);
 
     // TODO: add price limit, to decide whether use uint32 or SqrtPrice
     // TODO: add neighbor ticks/SqrtPrices that are already in the linked map, to decide whether use uint32 or SqrtPrice

--- a/src/library/LiquidityMath.sol
+++ b/src/library/LiquidityMath.sol
@@ -3,9 +3,12 @@ pragma solidity ^0.8.0;
 
 import {SqrtPrice} from "../models/SqrtPrice.sol";
 import {FullMath} from "./FullMath.sol";
+import {SafeCast} from "./SafeCast.sol";
 
 /// @title Liquidity math library
 library LiquidityMath {
+    using SafeCast for uint256;
+
     function getAmount0(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
         internal
         pure
@@ -40,8 +43,15 @@ library LiquidityMath {
         pure
         returns (uint128 liquidityUpper)
     {
-        // TODO: implement
-        // liquidityUpper = amount0 * (sqrtPrice * sqrtPriceUpper) / (sqrtPriceUpper - sqrtPrice)
+        liquidityUpper = FullMath.mulDivN(
+            amount0,
+            FullMath.mulDiv(
+                SqrtPrice.unwrap(sqrtPrice),
+                SqrtPrice.unwrap(sqrtPriceUpper),
+                SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPrice)
+            ),
+            96
+        ).toUint128();
     }
 
     function getLiquidityLower(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceLower, uint256 amount1)
@@ -49,7 +59,7 @@ library LiquidityMath {
         pure
         returns (uint128 liquidityLower)
     {
-        // TODO: implement
-        // liquidityLower = amount1 / (sqrtPrice - sqrtPriceLower)
+        liquidityLower =
+            FullMath.mulNDiv(amount1, 96, SqrtPrice.unwrap(sqrtPrice) - SqrtPrice.unwrap(sqrtPriceLower)).toUint128();
     }
 }

--- a/src/library/LiquidityMath.sol
+++ b/src/library/LiquidityMath.sol
@@ -1,0 +1,55 @@
+// SPDX-License-Identifier: MIT
+pragma solidity ^0.8.0;
+
+import {SqrtPrice} from "../models/SqrtPrice.sol";
+import {FullMath} from "./FullMath.sol";
+
+/// @title Liquidity math library
+library LiquidityMath {
+    function getAmount0(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
+        internal
+        pure
+        returns (uint256 amount0)
+    {
+        uint256 numerator1 = uint256(liquidity) << 96;
+        uint256 numerator2 = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
+
+        if (roundUp) {
+            amount0 = FullMath.mulDivUp(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper));
+
+            assembly ("memory-safe") {
+                amount0 := add(div(amount0, sqrtPriceLower), and(gt(mod(amount0, sqrtPriceLower), 0), roundUp))
+            }
+        } else {
+            FullMath.mulDiv(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper)) / SqrtPrice.unwrap(sqrtPriceLower);
+        }
+    }
+
+    function getAmount1(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
+        internal
+        pure
+        returns (uint256 amount1)
+    {
+        uint256 numerator = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
+
+        amount1 = roundUp ? FullMath.mulDivNUp(liquidity, numerator, 96) : FullMath.mulDivN(liquidity, numerator, 96);
+    }
+
+    function getLiquidityUpper(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceUpper, uint256 amount0)
+        internal
+        pure
+        returns (uint128 liquidityUpper)
+    {
+        // TODO: implement
+        // liquidityUpper = amount0 * (sqrtPrice * sqrtPriceUpper) / (sqrtPriceUpper - sqrtPrice)
+    }
+
+    function getLiquidityLower(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceLower, uint256 amount1)
+        internal
+        pure
+        returns (uint128 liquidityLower)
+    {
+        // TODO: implement
+        // liquidityLower = amount1 / (sqrtPrice - sqrtPriceLower)
+    }
+}

--- a/src/library/LiquidityMath.sol
+++ b/src/library/LiquidityMath.sol
@@ -21,7 +21,7 @@ library LiquidityMath {
             amount0 = FullMath.mulDivUp(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper));
 
             assembly ("memory-safe") {
-                amount0 := add(div(amount0, sqrtPriceLower), and(gt(mod(amount0, sqrtPriceLower), 0), roundUp))
+                amount0 := add(div(amount0, sqrtPriceLower), gt(mod(amount0, sqrtPriceLower), 0))
             }
         } else {
             FullMath.mulDiv(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper)) / SqrtPrice.unwrap(sqrtPriceLower);

--- a/src/library/LiquidityMath.sol
+++ b/src/library/LiquidityMath.sol
@@ -25,7 +25,8 @@ library LiquidityMath {
                 amount0 := add(div(amount0, sqrtPriceLower), gt(mod(amount0, sqrtPriceLower), 0))
             }
         } else {
-            FullMath.mulDiv(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper)) / SqrtPrice.unwrap(sqrtPriceLower);
+            amount0 = FullMath.mulDiv(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper))
+                / SqrtPrice.unwrap(sqrtPriceLower);
         }
     }
 

--- a/src/library/LiquidityMath.sol
+++ b/src/library/LiquidityMath.sol
@@ -20,6 +20,7 @@ library LiquidityMath {
         if (roundUp) {
             amount0 = FullMath.mulDivUp(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper));
 
+            // TODO: not checking for overflow, but should be impooosible in practice
             assembly ("memory-safe") {
                 amount0 := add(div(amount0, sqrtPriceLower), gt(mod(amount0, sqrtPriceLower), 0))
             }

--- a/src/library/SafeCast.sol
+++ b/src/library/SafeCast.sol
@@ -11,6 +11,16 @@ library SafeCast {
         if (y < 0) revert SafeCastOverflow();
     }
 
+    function toUint128(uint256 x) internal pure returns (uint128 y) {
+        y = uint128(x);
+        if (y != x) revert SafeCastOverflow();
+    }
+
+    function toUint160(uint256 x) internal pure returns (uint160 y) {
+        y = uint160(x);
+        if (y != x) revert SafeCastOverflow();
+    }
+
     function uint256toInt128(uint256 x) internal pure returns (int128) {
         if (x >= 1 << 127) revert SafeCastOverflow();
         return int128(int256(x));

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -2,13 +2,14 @@
 pragma solidity =0.8.28;
 
 import {IShareToken} from "../interfaces/IShareToken.sol";
-import {SafeCast} from "../library/SafeCast.sol";
 import {FullMath} from "../library/FullMath.sol";
+import {LiquidityMath} from "../library/LiquidityMath.sol";
+import {SafeCast} from "../library/SafeCast.sol";
 import {ShareToken} from "../ShareToken.sol";
 import {BalanceDelta, toBalanceDelta} from "./BalanceDelta.sol";
 import {PoolId} from "./PoolId.sol";
 import {PoolKey} from "./PoolKey.sol";
-import {SqrtPrice, SqrtPriceLibrary} from "./SqrtPrice.sol";
+import {SqrtPrice} from "./SqrtPrice.sol";
 import {OrderLevel, OrderLevelLibrary} from "./OrderLevel.sol";
 
 struct Pool {
@@ -71,12 +72,12 @@ library PoolLibrary {
         SqrtPrice sqrtPriceUpper =
             SqrtPrice.wrap(FullMath.mulDiv(SqrtPrice.unwrap(sqrtPrice), rangeRatioUpper, 1e6).toUint160());
 
-        uint128 liquidityLower = SqrtPriceLibrary.getLiquidityLower(sqrtPrice, sqrtPriceLower, amount1Desired);
-        uint128 liquidityUpper = SqrtPriceLibrary.getLiquidityUpper(sqrtPrice, sqrtPriceUpper, amount0Desired);
+        uint128 liquidityLower = LiquidityMath.getLiquidityLower(sqrtPrice, sqrtPriceLower, amount1Desired);
+        uint128 liquidityUpper = LiquidityMath.getLiquidityUpper(sqrtPrice, sqrtPriceUpper, amount0Desired);
 
         shares = liquidityLower > liquidityUpper ? liquidityUpper : liquidityLower;
-        uint256 amount0 = SqrtPriceLibrary.getAmount0(sqrtPrice, sqrtPriceUpper, shares + minShares, true);
-        uint256 amount1 = SqrtPriceLibrary.getAmount1(sqrtPriceLower, sqrtPrice, shares + minShares, true);
+        uint256 amount0 = LiquidityMath.getAmount0(sqrtPrice, sqrtPriceUpper, shares + minShares, true);
+        uint256 amount1 = LiquidityMath.getAmount1(sqrtPriceLower, sqrtPrice, shares + minShares, true);
         balanceDelta = toBalanceDelta(-amount0.uint256toInt128(), -amount1.uint256toInt128());
 
         self.reserve0 = amount0.toUint128();

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -54,17 +54,16 @@ library PoolLibrary {
         require(!self.isInitialized(), PoolAlreadyInitialized());
         require(SqrtPrice.unwrap(sqrtPrice) != 0, SqrtPriceCannotBeZero());
 
-        PoolId poolId = poolKey.toId();
         (
             uint24 rangeRatioLower,
             uint24 rangeRatioUpper,
             uint24 thresholdRatioLower,
             uint24 thresholdRatioUpper,
             uint32 minShares
-        ) = poolKey.configs.initialize(poolId, poolKey.token0, poolKey.token1, sqrtPrice);
+        ) = poolKey.configs.initialize(poolKey.token0, poolKey.token1, sqrtPrice);
         // TODO: validate returned values
 
-        shareToken = new ShareToken{salt: PoolId.unwrap(poolId)}();
+        shareToken = new ShareToken{salt: PoolId.unwrap(poolKey.toId())}();
 
         // TODO: hardcoding 1e6 for now
         SqrtPrice sqrtPriceLower =
@@ -74,8 +73,8 @@ library PoolLibrary {
 
         uint128 liquidityLower = LiquidityMath.getLiquidityLower(sqrtPrice, sqrtPriceLower, amount1Desired);
         uint128 liquidityUpper = LiquidityMath.getLiquidityUpper(sqrtPrice, sqrtPriceUpper, amount0Desired);
-
         shares = liquidityLower > liquidityUpper ? liquidityUpper : liquidityLower;
+
         uint256 amount0 = LiquidityMath.getAmount0(sqrtPrice, sqrtPriceUpper, shares + minShares, true);
         uint256 amount1 = LiquidityMath.getAmount1(sqrtPriceLower, sqrtPrice, shares + minShares, true);
         balanceDelta = toBalanceDelta(-amount0.uint256toInt128(), -amount1.uint256toInt128());

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -75,8 +75,8 @@ library PoolLibrary {
         uint128 liquidityUpper = LiquidityMath.getLiquidityUpper(sqrtPrice, sqrtPriceUpper, amount0Desired);
         shares = liquidityLower > liquidityUpper ? liquidityUpper : liquidityLower;
 
-        uint256 amount0 = LiquidityMath.getAmount0(sqrtPrice, sqrtPriceUpper, shares + minShares, true);
-        uint256 amount1 = LiquidityMath.getAmount1(sqrtPriceLower, sqrtPrice, shares + minShares, true);
+        uint256 amount0 = LiquidityMath.getAmount0(sqrtPrice, sqrtPriceUpper, shares, true);
+        uint256 amount1 = LiquidityMath.getAmount1(sqrtPriceLower, sqrtPrice, shares, true);
         balanceDelta = toBalanceDelta(-amount0.uint256toInt128(), -amount1.uint256toInt128());
 
         self.reserve0 = amount0.toUint128();
@@ -92,7 +92,7 @@ library PoolLibrary {
         self.orderLevels.initialize();
 
         shareToken.mint(address(0), minShares);
-        shareToken.mint(msg.sender, shares);
+        shareToken.mint(msg.sender, shares - minShares);
     }
 
     function modifyReserves(Pool storage self, int128 sharesDelta) internal returns (BalanceDelta balanceDelta) {

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -104,8 +104,8 @@ library PoolLibrary {
             uint256 amount0 = FullMath.mulDivUp(self.reserve0, uint128(sharesDelta), totalShares);
             uint256 amount1 = FullMath.mulDivUp(self.reserve1, uint128(sharesDelta), totalShares);
 
-            self.reserve0 += uint128(amount0.uint256toInt128());
-            self.reserve1 += uint128(amount1.uint256toInt128());
+            self.reserve0 += amount0.toUint128();
+            self.reserve1 += amount1.toUint128();
             balanceDelta = toBalanceDelta(-amount0.uint256toInt128(), -amount1.uint256toInt128());
 
             self.shareToken.mint(msg.sender, uint128(sharesDelta));

--- a/src/models/Pool.sol
+++ b/src/models/Pool.sol
@@ -3,7 +3,10 @@ pragma solidity =0.8.28;
 
 import {IConfigs} from "../interfaces/IConfigs.sol";
 import {IShareToken} from "../interfaces/IShareToken.sol";
-import {SqrtPrice} from "./SqrtPrice.sol";
+import {SafeCast} from "../library/SafeCast.sol";
+import {FullMath} from "../library/FullMath.sol";
+import {BalanceDelta, toBalanceDelta} from "./BalanceDelta.sol";
+import {SqrtPrice, SqrtPriceLibrary} from "./SqrtPrice.sol";
 import {OrderLevel, OrderLevelLibrary} from "./OrderLevel.sol";
 
 struct Pool {
@@ -20,6 +23,8 @@ struct Pool {
     mapping(SqrtPrice => OrderLevel) orderLevels;
 }
 
+using SafeCast for uint128;
+using SafeCast for uint256;
 using PoolLibrary for Pool global;
 
 /// @title PoolLibrary
@@ -27,26 +32,72 @@ library PoolLibrary {
     /// @notice Thrown when the pool is already initialized
     error PoolAlreadyInitialized();
 
+    /// @notice Thrown when the pool is not initialized
+    error PoolNotInitialized();
+
     /// @notice Thrown when the square root price is zero
     error SqrtPriceCannotBeZero();
 
+    using SafeCast for uint256;
     using OrderLevelLibrary for mapping(SqrtPrice => OrderLevel);
 
-    /// @notice Initialize the pool
-    /// @param self The pool
-    /// @param shareToken The share token contract
-    /// @param sqrtPrice The initial square root price
-    /// @param configs The configs contract
-    function initialize(Pool storage self, IShareToken shareToken, SqrtPrice sqrtPrice, IConfigs configs)
-        internal
-        returns (uint24 rangeRatioLower, uint24 rangeRatioUpper, uint24 thresholdRatioLower, uint24 thresholdRatioUpper)
-    {
+    // /// @notice Initialize the pool
+    // /// @param self The pool
+    // /// @param shareToken The share token contract
+    // /// @param sqrtPrice The initial square root price
+    // /// @param configs The configs contract
+    // function initialize(
+    //     Pool storage self,
+    //     IShareToken shareToken,
+    //     SqrtPrice sqrtPrice,
+    //     IConfigs configs,
+    //     uint128 liquidity
+    // ) internal returns (BalanceDelta balanceDelta) {
+
+    //     int128 amount0 = SqrtPriceLibrary.getAmount0(sqrtPrice, sqrtPriceUpper, liquidity, true).uint256toInt128();
+    //     int128 amount1 = SqrtPriceLibrary.getAmount1(sqrtPriceLower, sqrtPrice, liquidity, true).uint256toInt128();
+
+    //
+    // }
+
+    function initialize(
+        Pool storage self,
+        IConfigs configs,
+        IShareToken shareToken,
+        SqrtPrice sqrtPrice,
+        uint128 amount0Desired,
+        uint128 amount1Desired
+    ) internal returns (uint128 shares, BalanceDelta balanceDelta) {
         require(!self.isInitialized(), PoolAlreadyInitialized());
         require(SqrtPrice.unwrap(sqrtPrice) != 0, SqrtPriceCannotBeZero());
 
-        (rangeRatioLower, rangeRatioUpper, thresholdRatioLower, thresholdRatioUpper) =
+        (uint24 rangeRatioLower, uint24 rangeRatioUpper, uint24 thresholdRatioLower, uint24 thresholdRatioUpper) =
             configs.getRatios(sqrtPrice, 0, 0);
+        // TODO: need to validate ratio values
+        // TODO: get MIN_LIQUIDITY from configs
 
+        // TODO: not safe, neet to check for overflow
+        // TODO: hardcoded 1e6 for now, move to somewhere else
+        uint256 sqrtPriceLower = FullMath.mulDiv(SqrtPrice.unwrap(sqrtPrice), rangeRatioLower, 1e6);
+        uint256 sqrtPriceUpper = FullMath.mulDiv(SqrtPrice.unwrap(sqrtPrice), rangeRatioUpper, 1e6);
+
+        // TODO: wait for liquidity library
+        uint128 liquidityLower;
+        uint128 liquidityUpper;
+
+        // TODO: wait for liquidity library
+        uint128 amount0;
+        uint128 amount1;
+        if (liquidityLower > liquidityUpper) {
+            shares = liquidityUpper;
+        } else {
+            shares = liquidityLower;
+        }
+
+        balanceDelta = toBalanceDelta(-amount0.toInt128(), -amount1.toInt128());
+
+        self.reserve0 = amount0;
+        self.reserve1 = amount1;
         self.shareToken = shareToken;
         self.sqrtPrice = sqrtPrice;
         self.rangeRatioLower = rangeRatioLower;
@@ -56,6 +107,28 @@ library PoolLibrary {
         self.bestAsk = SqrtPrice.wrap(0);
         self.bestBid = SqrtPrice.wrap(type(uint160).max);
         self.orderLevels.initialize();
+    }
+
+    function modifyReserves(Pool storage self, int128 sharesDelta) internal returns (BalanceDelta balanceDelta) {
+        require(self.isInitialized(), PoolNotInitialized());
+
+        uint256 totalShares = self.shareToken.totalSupply();
+
+        if (sharesDelta > 0) {
+            uint256 amount0 = FullMath.mulDivUp(self.reserve0, uint128(sharesDelta), totalShares);
+            uint256 amount1 = FullMath.mulDivUp(self.reserve1, uint128(sharesDelta), totalShares);
+
+            self.reserve0 += uint128(amount0.uint256toInt128());
+            self.reserve1 += uint128(amount1.uint256toInt128());
+            balanceDelta = toBalanceDelta(-amount0.uint256toInt128(), -amount1.uint256toInt128());
+        } else {
+            uint256 amount0 = FullMath.mulDiv(self.reserve0, uint128(-sharesDelta), totalShares);
+            uint256 amount1 = FullMath.mulDiv(self.reserve1, uint128(-sharesDelta), totalShares);
+
+            self.reserve0 -= uint128(amount0.uint256toInt128());
+            self.reserve1 -= uint128(amount1.uint256toInt128());
+            balanceDelta = toBalanceDelta(amount0.uint256toInt128(), amount1.uint256toInt128());
+        }
     }
 
     // TODO: all other functions needs to check that pool is initialized

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -7,7 +7,6 @@ import {FullMath} from "../library/FullMath.sol";
 type SqrtPrice is uint160;
 
 using {equals as ==, notEquals as !=, greaterThan as >, lessThan as <} for SqrtPrice global;
-using SqrtPriceLibrary for SqrtPrice global;
 
 function equals(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
     return SqrtPrice.unwrap(sqrtPrice) == SqrtPrice.unwrap(other);
@@ -31,8 +30,6 @@ library SqrtPriceLibrary {
         pure
         returns (uint256 amount0)
     {
-        // TODO: check sqrtPriceLower greater than 0
-
         uint256 numerator1 = uint256(liquidity) << 96;
         uint256 numerator2 = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
 
@@ -55,5 +52,23 @@ library SqrtPriceLibrary {
         uint256 numerator = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
 
         amount1 = roundUp ? FullMath.mulDivNUp(liquidity, numerator, 96) : FullMath.mulDivN(liquidity, numerator, 96);
+    }
+
+    function getLiquidityUpper(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceUpper, uint256 amount0)
+        internal
+        pure
+        returns (uint128 liquidityUpper)
+    {
+        // TODO: implement
+        // liquidityUpper = amount0 * (sqrtPrice * sqrtPriceUpper) / (sqrtPriceUpper - sqrtPrice)
+    }
+
+    function getLiquidityLower(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceLower, uint256 amount1)
+        internal
+        pure
+        returns (uint128 liquidityLower)
+    {
+        // TODO: implement
+        // liquidityLower = amount1 / (sqrtPrice - sqrtPriceLower)
     }
 }

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -1,10 +1,13 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
+import {FullMath} from "../library/FullMath.sol";
+
 /// @dev Represented as Q96.96 fixed point number
 type SqrtPrice is uint160;
 
 using {equals as ==, notEquals as !=, greaterThan as >, lessThan as <} for SqrtPrice global;
+using SqrtPriceLibrary for SqrtPrice global;
 
 function equals(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
     return SqrtPrice.unwrap(sqrtPrice) == SqrtPrice.unwrap(other);
@@ -20,4 +23,37 @@ function greaterThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
 
 function lessThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
     return SqrtPrice.unwrap(sqrtPrice) < SqrtPrice.unwrap(other);
+}
+
+library SqrtPriceLibrary {
+    function getAmount0(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
+        internal
+        pure
+        returns (uint256 amount0)
+    {
+        // TODO: check sqrtPriceLower greater than 0
+
+        uint256 numerator1 = uint256(liquidity) << 96;
+        uint256 numerator2 = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
+
+        if (roundUp) {
+            amount0 = FullMath.mulDivUp(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper));
+
+            assembly ("memory-safe") {
+                amount0 := add(div(amount0, sqrtPriceLower), and(gt(mod(amount0, sqrtPriceLower), 0), roundUp))
+            }
+        } else {
+            FullMath.mulDiv(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper)) / SqrtPrice.unwrap(sqrtPriceLower);
+        }
+    }
+
+    function getAmount1(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
+        internal
+        pure
+        returns (uint256 amount1)
+    {
+        uint256 numerator = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
+
+        amount1 = roundUp ? FullMath.mulDivNUp(liquidity, numerator, 96) : FullMath.mulDivN(liquidity, numerator, 96);
+    }
 }

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -1,8 +1,6 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-import {FullMath} from "../library/FullMath.sol";
-
 /// @dev Represented as Q96.96 fixed point number
 type SqrtPrice is uint160;
 
@@ -22,53 +20,4 @@ function greaterThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
 
 function lessThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
     return SqrtPrice.unwrap(sqrtPrice) < SqrtPrice.unwrap(other);
-}
-
-library SqrtPriceLibrary {
-    function getAmount0(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
-        internal
-        pure
-        returns (uint256 amount0)
-    {
-        uint256 numerator1 = uint256(liquidity) << 96;
-        uint256 numerator2 = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
-
-        if (roundUp) {
-            amount0 = FullMath.mulDivUp(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper));
-
-            assembly ("memory-safe") {
-                amount0 := add(div(amount0, sqrtPriceLower), and(gt(mod(amount0, sqrtPriceLower), 0), roundUp))
-            }
-        } else {
-            FullMath.mulDiv(numerator1, numerator2, SqrtPrice.unwrap(sqrtPriceUpper)) / SqrtPrice.unwrap(sqrtPriceLower);
-        }
-    }
-
-    function getAmount1(SqrtPrice sqrtPriceLower, SqrtPrice sqrtPriceUpper, uint128 liquidity, bool roundUp)
-        internal
-        pure
-        returns (uint256 amount1)
-    {
-        uint256 numerator = SqrtPrice.unwrap(sqrtPriceUpper) - SqrtPrice.unwrap(sqrtPriceLower);
-
-        amount1 = roundUp ? FullMath.mulDivNUp(liquidity, numerator, 96) : FullMath.mulDivN(liquidity, numerator, 96);
-    }
-
-    function getLiquidityUpper(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceUpper, uint256 amount0)
-        internal
-        pure
-        returns (uint128 liquidityUpper)
-    {
-        // TODO: implement
-        // liquidityUpper = amount0 * (sqrtPrice * sqrtPriceUpper) / (sqrtPriceUpper - sqrtPrice)
-    }
-
-    function getLiquidityLower(SqrtPrice sqrtPrice, SqrtPrice sqrtPriceLower, uint256 amount1)
-        internal
-        pure
-        returns (uint128 liquidityLower)
-    {
-        // TODO: implement
-        // liquidityLower = amount1 / (sqrtPrice - sqrtPriceLower)
-    }
 }


### PR DESCRIPTION
Re-do initialize:
- Takes desired amounts, calculate the lower share and balance delta required, reason for this is the user/front end may not know the liquidity range beforehand 
- Move share token creation from pool manager to pool
- Get min liquidity from IConfigs

Mint/burn -> modifyReserve
- Takes sharesDelta and return balance delta