### PR TITLE
Tick to sqrt price

### DIFF
--- a/src/models/Price.sol
+++ b/src/models/Price.sol
@@ -5,7 +5,7 @@ import {SqrtPrice} from "./SqrtPrice.sol";
 import {FullMath} from "../library/FullMath.sol";
 import {SafeCast} from "../library/SafeCast.sol";
 
-/// @dev Represented as Q96.96 fixed point number
+/// @dev Represented as Q160.96 fixed point number
 type Price is uint256;
 
 using PriceLibrary for Price global;

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -21,3 +21,60 @@ function greaterThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
 function lessThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
     return SqrtPrice.unwrap(sqrtPrice) < SqrtPrice.unwrap(other);
 }
+
+library SqrtPriceLibrary {
+    error InvalidTick(int32 tick);
+
+    int32 internal constant MIN_TICK = -110903604;
+    int32 internal constant MAX_TICK = 110903603;
+    // c0 = 0.0000014 * 2^96
+    // 2^0.0000014 = 1.00000097
+    int256 internal constant c0 = 0x177cf44765195f0000000000000000000000000000000;
+
+    function fromTick(int32 tick) internal pure returns (SqrtPrice sqrtPrice) {
+        unchecked {
+            uint256 absTick;
+
+            assembly ("memory-safe") {
+                tick := signextend(3, tick)
+                let mask := sar(255, tick)
+                absTick := xor(mask, add(mask, tick))
+            }
+
+            if (absTick > uint256(int256(MAX_TICK))) revert InvalidTick(tick);
+
+            uint256 ratio =
+                absTick & 0x1 != 0 ? 0xfffff79c84993593430be84302e41e86 : 0x100000000000000000000000000000000;
+
+            if (absTick & 0x2 != 0) ratio = (ratio * 0xffffef390978c9859fbb1c39d85752bf) >> 128;
+            if (absTick & 0x4 != 0) ratio = (ratio * 0xffffde72140b0c7e6cd5ede6e9658a7e) >> 128;
+            if (absTick & 0x8 != 0) ratio = (ratio * 0xffffbce42c7bfe7fc5c321ebc29c80d8) >> 128;
+            if (absTick & 0x10 != 0) ratio = (ratio * 0xffff79c86a8f90bcf0ea91ea968d17a0) >> 128;
+            if (absTick & 0x20 != 0) ratio = (ratio * 0xfffef3911b7d5dfd23db3955b2254463) >> 128;
+            if (absTick & 0x40 != 0) ratio = (ratio * 0xfffde72350731a74f7289d4b9d6a8c03) >> 128;
+            if (absTick & 0x80 != 0) ratio = (ratio * 0xfffbce4b06c312462213e5f44e5448bd) >> 128;
+            if (absTick & 0x100 != 0) ratio = (ratio * 0xfff79ca7a4d4b5cc754dc491c09a367e) >> 128;
+            if (absTick & 0x200 != 0) ratio = (ratio * 0xffef3995a5bc934fd772e30f1405a8dd) >> 128;
+            if (absTick & 0x400 != 0) ratio = (ratio * 0xffde7444b28d1edc70b4d28b92a70335) >> 128;
+            if (absTick & 0x800 != 0) ratio = (ratio * 0xffbceceeb7a9247bea546d0486616d52) >> 128;
+            if (absTick & 0x1000 != 0) ratio = (ratio * 0xff79eb706bc9b856505bed8cda29b046) >> 128;
+            if (absTick & 0x2000 != 0) ratio = (ratio * 0xfef41d1a5f89592f0c011c3f63c8f5ea) >> 128;
+            if (absTick & 0x4000 != 0) ratio = (ratio * 0xfde95287d329a72807431653d1ce83b2) >> 128;
+            if (absTick & 0x8000 != 0) ratio = (ratio * 0xfbd701c7cd3a018e78697371e8458311) >> 128;
+            if (absTick & 0x10000 != 0) ratio = (ratio * 0xf7bf5211ca0da207262485942f0eb194) >> 128;
+            if (absTick & 0x20000 != 0) ratio = (ratio * 0xefc2bf59e4c135aec35b0212dfd1cd6a) >> 128;
+            if (absTick & 0x40000 != 0) ratio = (ratio * 0xe08d35706c66b9fad67ed8454da311be) >> 128;
+            if (absTick & 0x80000 != 0) ratio = (ratio * 0xc4f76b68a6b2ece16679b0a418b946d2) >> 128;
+            if (absTick & 0x100000 != 0) ratio = (ratio * 0x978bcb98b0444e1fafcf805db494c9ac) >> 128;
+            if (absTick & 0x200000 != 0) ratio = (ratio * 0x59b63684d9ab80f45630b8dcf730b4f2) >> 128;
+            if (absTick & 0x400000 != 0) ratio = (ratio * 0x1f703399efdb104acbb0b1a9afca311c) >> 128;
+            if (absTick & 0x800000 != 0) ratio = (ratio * 0x3dc5dac792f9fc23bd91012f6609d09) >> 128;
+            if (absTick & 0x1000000 != 0) ratio = (ratio * 0xee7e32d8e2bd8ceadcdd1dd511ed5) >> 128;
+            if (absTick & 0x2000000 != 0) ratio = (ratio * 0xde2ee4c15d3114ecdd9950e4ae) >> 128;
+            if (absTick & 0x4000000 != 0) ratio = (ratio * 0xc0d55d565f879dfb68a9) >> 128;
+
+            if (tick > 0) ratio = type(uint256).max / ratio;
+            sqrtPrice = SqrtPrice.wrap(uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1)));
+        }
+    }
+}

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -1,7 +1,7 @@
 // SPDX-License-Identifier: MIT
 pragma solidity ^0.8.0;
 
-/// @dev Represented as Q96.96 fixed point number
+/// @dev Represented as Q64.96 fixed point number
 type SqrtPrice is uint160;
 
 using {equals as ==, notEquals as !=, greaterThan as >, lessThan as <} for SqrtPrice global;

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -43,38 +43,49 @@ library SqrtPriceLibrary {
 
             if (absTick > uint256(int256(MAX_TICK))) revert InvalidTick(tick);
 
-            uint256 ratio =
-                absTick & 0x1 != 0 ? 0xfffff79c84993593430be84302e41e86 : 0x100000000000000000000000000000000;
+            uint256 price;
+            assembly ("memory-safe") {
+                price := xor(shl(128, 1), mul(xor(shl(128, 1), 0xfffff79c84993593430be84302e41e86), and(absTick, 0x1)))
+            }
 
-            if (absTick & 0x2 != 0) ratio = (ratio * 0xffffef390978c9859fbb1c39d85752bf) >> 128;
-            if (absTick & 0x4 != 0) ratio = (ratio * 0xffffde72140b0c7e6cd5ede6e9658a7e) >> 128;
-            if (absTick & 0x8 != 0) ratio = (ratio * 0xffffbce42c7bfe7fc5c321ebc29c80d8) >> 128;
-            if (absTick & 0x10 != 0) ratio = (ratio * 0xffff79c86a8f90bcf0ea91ea968d17a0) >> 128;
-            if (absTick & 0x20 != 0) ratio = (ratio * 0xfffef3911b7d5dfd23db3955b2254463) >> 128;
-            if (absTick & 0x40 != 0) ratio = (ratio * 0xfffde72350731a74f7289d4b9d6a8c03) >> 128;
-            if (absTick & 0x80 != 0) ratio = (ratio * 0xfffbce4b06c312462213e5f44e5448bd) >> 128;
-            if (absTick & 0x100 != 0) ratio = (ratio * 0xfff79ca7a4d4b5cc754dc491c09a367e) >> 128;
-            if (absTick & 0x200 != 0) ratio = (ratio * 0xffef3995a5bc934fd772e30f1405a8dd) >> 128;
-            if (absTick & 0x400 != 0) ratio = (ratio * 0xffde7444b28d1edc70b4d28b92a70335) >> 128;
-            if (absTick & 0x800 != 0) ratio = (ratio * 0xffbceceeb7a9247bea546d0486616d52) >> 128;
-            if (absTick & 0x1000 != 0) ratio = (ratio * 0xff79eb706bc9b856505bed8cda29b046) >> 128;
-            if (absTick & 0x2000 != 0) ratio = (ratio * 0xfef41d1a5f89592f0c011c3f63c8f5ea) >> 128;
-            if (absTick & 0x4000 != 0) ratio = (ratio * 0xfde95287d329a72807431653d1ce83b2) >> 128;
-            if (absTick & 0x8000 != 0) ratio = (ratio * 0xfbd701c7cd3a018e78697371e8458311) >> 128;
-            if (absTick & 0x10000 != 0) ratio = (ratio * 0xf7bf5211ca0da207262485942f0eb194) >> 128;
-            if (absTick & 0x20000 != 0) ratio = (ratio * 0xefc2bf59e4c135aec35b0212dfd1cd6a) >> 128;
-            if (absTick & 0x40000 != 0) ratio = (ratio * 0xe08d35706c66b9fad67ed8454da311be) >> 128;
-            if (absTick & 0x80000 != 0) ratio = (ratio * 0xc4f76b68a6b2ece16679b0a418b946d2) >> 128;
-            if (absTick & 0x100000 != 0) ratio = (ratio * 0x978bcb98b0444e1fafcf805db494c9ac) >> 128;
-            if (absTick & 0x200000 != 0) ratio = (ratio * 0x59b63684d9ab80f45630b8dcf730b4f2) >> 128;
-            if (absTick & 0x400000 != 0) ratio = (ratio * 0x1f703399efdb104acbb0b1a9afca311c) >> 128;
-            if (absTick & 0x800000 != 0) ratio = (ratio * 0x3dc5dac792f9fc23bd91012f6609d09) >> 128;
-            if (absTick & 0x1000000 != 0) ratio = (ratio * 0xee7e32d8e2bd8ceadcdd1dd511ed5) >> 128;
-            if (absTick & 0x2000000 != 0) ratio = (ratio * 0xde2ee4c15d3114ecdd9950e4ae) >> 128;
-            if (absTick & 0x4000000 != 0) ratio = (ratio * 0xc0d55d565f879dfb68a9) >> 128;
+            if (absTick & 0x2 != 0) price = (price * 0xffffef390978c9859fbb1c39d85752bf) >> 128;
+            if (absTick & 0x4 != 0) price = (price * 0xffffde72140b0c7e6cd5ede6e9658a7e) >> 128;
+            if (absTick & 0x8 != 0) price = (price * 0xffffbce42c7bfe7fc5c321ebc29c80d8) >> 128;
+            if (absTick & 0x10 != 0) price = (price * 0xffff79c86a8f90bcf0ea91ea968d17a0) >> 128;
+            if (absTick & 0x20 != 0) price = (price * 0xfffef3911b7d5dfd23db3955b2254463) >> 128;
+            if (absTick & 0x40 != 0) price = (price * 0xfffde72350731a74f7289d4b9d6a8c03) >> 128;
+            if (absTick & 0x80 != 0) price = (price * 0xfffbce4b06c312462213e5f44e5448bd) >> 128;
+            if (absTick & 0x100 != 0) price = (price * 0xfff79ca7a4d4b5cc754dc491c09a367e) >> 128;
+            if (absTick & 0x200 != 0) price = (price * 0xffef3995a5bc934fd772e30f1405a8dd) >> 128;
+            if (absTick & 0x400 != 0) price = (price * 0xffde7444b28d1edc70b4d28b92a70335) >> 128;
+            if (absTick & 0x800 != 0) price = (price * 0xffbceceeb7a9247bea546d0486616d52) >> 128;
+            if (absTick & 0x1000 != 0) price = (price * 0xff79eb706bc9b856505bed8cda29b046) >> 128;
+            if (absTick & 0x2000 != 0) price = (price * 0xfef41d1a5f89592f0c011c3f63c8f5ea) >> 128;
+            if (absTick & 0x4000 != 0) price = (price * 0xfde95287d329a72807431653d1ce83b2) >> 128;
+            if (absTick & 0x8000 != 0) price = (price * 0xfbd701c7cd3a018e78697371e8458311) >> 128;
+            if (absTick & 0x10000 != 0) price = (price * 0xf7bf5211ca0da207262485942f0eb194) >> 128;
+            if (absTick & 0x20000 != 0) price = (price * 0xefc2bf59e4c135aec35b0212dfd1cd6a) >> 128;
+            if (absTick & 0x40000 != 0) price = (price * 0xe08d35706c66b9fad67ed8454da311be) >> 128;
+            if (absTick & 0x80000 != 0) price = (price * 0xc4f76b68a6b2ece16679b0a418b946d2) >> 128;
+            if (absTick & 0x100000 != 0) price = (price * 0x978bcb98b0444e1fafcf805db494c9ac) >> 128;
+            if (absTick & 0x200000 != 0) price = (price * 0x59b63684d9ab80f45630b8dcf730b4f2) >> 128;
+            if (absTick & 0x400000 != 0) price = (price * 0x1f703399efdb104acbb0b1a9afca311c) >> 128;
+            if (absTick & 0x800000 != 0) price = (price * 0x3dc5dac792f9fc23bd91012f6609d09) >> 128;
+            if (absTick & 0x1000000 != 0) price = (price * 0xee7e32d8e2bd8ceadcdd1dd511ed5) >> 128;
+            if (absTick & 0x2000000 != 0) price = (price * 0xde2ee4c15d3114ecdd9950e4ae) >> 128;
+            if (absTick & 0x4000000 != 0) price = (price * 0xc0d55d565f879dfb68a9) >> 128;
 
-            if (tick > 0) ratio = type(uint256).max / ratio;
-            sqrtPrice = SqrtPrice.wrap(uint160((ratio >> 32) + (ratio % (1 << 32) == 0 ? 0 : 1)));
+            assembly ("memory-safe") {
+                // if (tick > 0) price = type(uint256).max / price;
+                if sgt(tick, 0) { price := div(not(0), price) }
+
+                // this divides by 1<<32 rounding up to go from a Q128.128 to a Q128.96.
+                // we then downcast because we know the result always fits within 160 bits due to our tick input constraint
+                // we round up in the division so getTickAtSqrtPrice of the output price is always consistent
+                // `sub(shl(32, 1), 1)` is `type(uint32).max`
+                // `price + type(uint32).max` will not overflow because `price` fits in 192 bits
+                sqrtPrice := shr(32, add(price, sub(shl(32, 1), 1)))
+            }
         }
     }
 }

--- a/src/models/SqrtPrice.sol
+++ b/src/models/SqrtPrice.sol
@@ -24,12 +24,10 @@ function lessThan(SqrtPrice sqrtPrice, SqrtPrice other) pure returns (bool) {
 
 library SqrtPriceLibrary {
     error InvalidTick(int32 tick);
-
-    int32 internal constant MIN_TICK = -110903604;
-    int32 internal constant MAX_TICK = 110903603;
-    // c0 = 0.0000014 * 2^96
-    // 2^0.0000014 = 1.00000097
-    int256 internal constant c0 = 0x177cf44765195f0000000000000000000000000000000;
+    
+    // log_1.000001 2^128
+    int32 internal constant MIN_TICK = -88722883;
+    int32 internal constant MAX_TICK = 88722883;
 
     function fromTick(int32 tick) internal pure returns (SqrtPrice sqrtPrice) {
         unchecked {

--- a/test/models/SqrtPrice.t.sol
+++ b/test/models/SqrtPrice.t.sol
@@ -1,0 +1,22 @@
+// SPDX-License-Identifier: UNLICENSED
+pragma solidity ^0.8.0;
+
+import {Test} from "forge-std/Test.sol";
+import {SqrtPrice, SqrtPriceLibrary} from "../../src/models/SqrtPrice.sol";
+import {console} from "forge-std/console.sol";
+
+contract SqrtPriceTest is Test {
+    int32 constant MIN_TICK = SqrtPriceLibrary.MIN_TICK;
+    int32 constant MAX_TICK = SqrtPriceLibrary.MAX_TICK;
+
+    /// forge-config: default.allow_internal_expect_revert = true
+    function test_fuzz_fromTick_throwsForTooLarge(int32 tick) public {
+        if (tick > 0) {
+            tick = int32(bound(tick, MAX_TICK + 1, type(int32).max));
+        } else {
+            tick = int32(bound(tick, type(int32).min, MIN_TICK - 1));
+        }
+        vm.expectRevert(abi.encodeWithSelector(SqrtPriceLibrary.InvalidTick.selector, tick));
+        SqrtPriceLibrary.fromTick(tick);
+    }
+}

--- a/test/models/SqrtPrice.t.sol
+++ b/test/models/SqrtPrice.t.sol
@@ -8,6 +8,8 @@ import {console} from "forge-std/console.sol";
 contract SqrtPriceTest is Test {
     int32 constant MIN_TICK = SqrtPriceLibrary.MIN_TICK;
     int32 constant MAX_TICK = SqrtPriceLibrary.MAX_TICK;
+    uint160 internal constant MAX_SQRT_PRICE = 1461501286290052445479870394709391467910365253204;
+    uint160 internal constant MIN_SQRT_PRICE = 4294968328;
 
     /// forge-config: default.allow_internal_expect_revert = true
     function test_fuzz_fromTick_throwsForTooLarge(int32 tick) public {
@@ -18,5 +20,20 @@ contract SqrtPriceTest is Test {
         }
         vm.expectRevert(abi.encodeWithSelector(SqrtPriceLibrary.InvalidTick.selector, tick));
         SqrtPriceLibrary.fromTick(tick);
+    }
+
+    function test_fromTick_one() public pure {
+        SqrtPrice sqrtPrice = SqrtPriceLibrary.fromTick(0);
+        assertEq(SqrtPrice.unwrap(sqrtPrice), 1 << 96);
+    }
+
+    function test_fromTick_isValidMaxTick() public pure {
+        SqrtPrice sqrtPrice = SqrtPriceLibrary.fromTick(MAX_TICK);
+        assertEq(SqrtPrice.unwrap(sqrtPrice), MAX_SQRT_PRICE);
+    }
+
+    function test_fromTick_isValidMinTick() public pure {
+        SqrtPrice sqrtPrice = SqrtPriceLibrary.fromTick(MIN_TICK);
+        assertEq(SqrtPrice.unwrap(sqrtPrice), MIN_SQRT_PRICE);
     }
 }


### PR DESCRIPTION
The math of this code can be found in [this document](https://github.com/adshao/publications/blob/master/uniswap/dive-into-uniswap-v3-contracts/README_zh.md#getsqrtratioattick).

Some code is generated directly using Python:

```python
from mpmath import mp
mp.dps = 50

def q128_fixpoint(x):
    return hex(int(x * mp.power(2, 128)))

d = mp.mpf(1.000001)

c0 = q128_fixpoint(1 / mp.sqrt(d))
print(c0)

for i in range(1, 27):
    fixed_number = 2 ** i
    print(
        "if (absTick & 0x{:X} != 0) ratio = (ratio * {}) >> 128;".format(
            fixed_number,
            q128_fixpoint(1 / mp.power(d, fixed_number / 2))
        )
    )
```